### PR TITLE
Libraries

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,18 @@
 History
 =======
 
+0.6.2 (2022-01-28)
+------------------
+
+* Improvements on LocationSubscriber.
+A new method has been implemented with name
+``get_location_information``
+
+With the new method the net app developer has the option to request for location information for a device just once. No need to create subscriptions or maintain a local web server in order to get notified for location changes.
+When a call to ``get_location_information`` is made, the 5G-API responds instantly with the location information (the cell id the device, that is being monitored, is connected to)
+
+* Examples of usages have been updated
+File location_subscriber_examples.py now showcases how the new method can be called
 
 0.6.1 (2022-01-26)
 ------------------

--- a/evolved5g/__init__.py
+++ b/evolved5g/__init__.py
@@ -1,7 +1,7 @@
 """Top-level package for Evolved5G_CLI."""
 
 __author__ = "EVOLVED5G project"
-__version__ = '0.6.0'
+__version__ = '0.6.2'
 
 # Uncomment next lines to give direct import access to modules
 #from . import cli

--- a/evolved5g/sdk.py
+++ b/evolved5g/sdk.py
@@ -6,8 +6,8 @@ from enum import Enum
 from evolved5g.swagger_client import MonitoringEventAPIApi, \
     MonitoringEventSubscriptionCreate, MonitoringEventSubscription, SessionWithQoSAPIApi, \
     AsSessionWithQoSSubscriptionCreate, Snssai, UsageThreshold, AsSessionWithQoSSubscription, QosMonitoringInformation, \
-    RequestedQoSMonitoringParameters, ReportingFrequency
-
+    RequestedQoSMonitoringParameters, ReportingFrequency, MonitoringEventReport
+import datetime
 
 class LocationSubscriber:
 
@@ -39,12 +39,34 @@ class LocationSubscriber:
                                                  maximum_number_of_reports,
                                                  monitor_expire_time)
 
+    def get_location_information(self,netapp_id: str,
+                                 external_id) -> MonitoringEventReport:
+        """
+             Returns the location of a specific device.
+             This is equivalent to creating a subscription with maximum_number_of_reports = 1
+             :param str netapp_id: string (The ID of the Netapp that creates a subscription)
+             :param str external_id: Globally unique identifier containing a Domain Identifier and a Local Identifier. <Local Identifier>@<Domain Identifier>
+       """
+
+        # create a dummy expiration time. Since we are requesting for only 1 report, we will get the location information back instantly
+        monitor_expire_time = (datetime.datetime.utcnow() + datetime.timedelta(minutes=1)).isoformat() + "Z"
+        body = self.__create_subscription_request(external_id,
+                                                  None,
+                                                  maximum_number_of_reports=1,
+                                                  monitor_expire_time=monitor_expire_time)
+
+        # a monitoring event report
+        response = self.monitoring_event_api.create_subscription_api_v13gpp_monitoring_event_v1_scs_as_id_subscriptions_post(
+            body,
+            netapp_id)
+        return response
+
     def create_subscription(self,
                             netapp_id: str,
                             external_id,
                             notification_destination,
                             maximum_number_of_reports,
-                            monitor_expire_time):
+                            monitor_expire_time) -> MonitoringEventSubscription:
         """
               Creates a subscription that will be used to retrieve Location information about a device.
 

--- a/evolved5g/swagger_client/api/monitoring_event_api_api.py
+++ b/evolved5g/swagger_client/api/monitoring_event_api_api.py
@@ -131,13 +131,19 @@ class MonitoringEventAPIApi(object):
             body=body_params,
             post_params=form_params,
             files=local_var_files,
-            response_type='MonitoringEventSubscription',  # noqa: E501
+            response_type=self.get_response_type(body_params),  # noqa: E501
             auth_settings=auth_settings,
             async_req=params.get('async_req'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),
             collection_formats=collection_formats)
+
+    def get_response_type(self,body_params):
+        if body_params.maximum_number_of_reports ==1:
+            return "MonitoringEventReport"
+        else:
+            return "MonitoringEventSubscription"
 
     def delete_subscription_api_v13gpp_monitoring_event_v1_scs_as_id_subscriptions_subscription_id_delete(self, scs_as_id, subscription_id, **kwargs):  # noqa: E501
         """Delete Subscription  # noqa: E501

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.6.1
+current_version = 0.6.2
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/EVOLVED-5G/SDK-CLI',
-    version='0.6.1',
+    version='0.6.2',
     zip_safe=False,
 )


### PR DESCRIPTION
**Improvements on LocationSubscriber.**
A new method has been implemented with name  `get_location_information`
With the new method the net app developer has the option to request for location information for a device just once. No need to create subscriptions or maintain a local web server in order to get notified for location changes.
When a call to `get_location_information` is made, the 5G-API responds instantly with the location information (the cell id the device is connected to)

**Examples of usages have been updated**
File _location_subscriber_examples.py_ now showcases how the new method can be called