### PR TITLE
Update on LocationSubscriber SDK class

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,10 @@
 =======
 History
 =======
+0.7.2  (2022-04-01)
+-------------------
+* LocationSubscriber now has a new method get_coordinates_of_cell() that allows a developer to retrieve the location of a cell, given the cell id.
+
 
 0.7.1  (2022-03-14)
 -------------------

--- a/evolved5g/__init__.py
+++ b/evolved5g/__init__.py
@@ -1,7 +1,7 @@
 """Top-level package for Evolved5G_CLI."""
 
 __author__ = "EVOLVED5G project"
-__version__ = '0.7.1'
+__version__ = '0.7.2'
 
 # Uncomment next lines to give direct import access to modules
 #from . import cli

--- a/evolved5g/sdk.py
+++ b/evolved5g/sdk.py
@@ -6,7 +6,7 @@ from enum import Enum
 from evolved5g.swagger_client import MonitoringEventAPIApi, \
     MonitoringEventSubscriptionCreate, MonitoringEventSubscription, SessionWithQoSAPIApi, \
     AsSessionWithQoSSubscriptionCreate, Snssai, UsageThreshold, AsSessionWithQoSSubscription, QosMonitoringInformation, \
-    RequestedQoSMonitoringParameters, ReportingFrequency, MonitoringEventReport
+    RequestedQoSMonitoringParameters, ReportingFrequency, MonitoringEventReport, CellsApi, Cell
 import datetime
 
 class LocationSubscriber:
@@ -26,6 +26,7 @@ class LocationSubscriber:
         configuration.access_token = bearer_access_token
         api_client = swagger_client.ApiClient(configuration=configuration)
         self.monitoring_event_api = MonitoringEventAPIApi(api_client)
+        self.cell_api = CellsApi(api_client)
 
     def __create_subscription_request(self,
                                       external_id,
@@ -60,6 +61,14 @@ class LocationSubscriber:
             body,
             netapp_id)
         return response
+
+    def get_coordinates_of_cell(self,cell_id:str)->Cell:
+        """
+             Returns information about a specific cell
+
+             :param str cell_id: string (The ID of the cell)
+       """
+        return self.cell_api.read_cell_api_v1_cells_cell_id_get(cell_id)
 
     def create_subscription(self,
                             netapp_id: str,

--- a/examples/qos_awereness_examples.py
+++ b/examples/qos_awereness_examples.py
@@ -22,10 +22,10 @@ def showcase_create_quaranteed_bit_rate_subscription_for_conversational_voice():
     qos_awereness = QosAwareness(host, token.access_token)
     # The following external identifier was copy pasted by the NEF emulator.
     # Go to the Map and hover over a User icon.There you can retrieve the id address.
-    # Notice that the MEF emulator is able to establish a guaranteed bit rate only if one and only one user is connected to a shell
+    # Notice that the NEF emulator is able to establish a guaranteed bit rate only if one and only one user is connected to a shell
     # This is done in purpose in the NEF emulator, to allow testing the lost of guaranteed connectivity to your code
-    # in the MEF if a user "10.0.0.3" is connected to Cell only by her self (she is the only connection within range)
-    # the MEF guarantees the connection. If another user walks by, within the same Cell range then the connection is no
+    # in the NEF if a user "10.0.0.3" is connected to Cell only by her self (she is the only connection within range)
+    # the NEF guarantees the connection. If another user walks by, within the same Cell range then the connection is no
     # more guaranteed and a callback notification will be retrieved.
     equipment_network_identifier = "10.0.0.3"
     network_identifier = QosAwareness.NetworkIdentifier.IP_V4_ADDRESS

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.7.1
+current_version = 0.7.2
 commit = True
 tag = True
 


### PR DESCRIPTION
LocationSubscriber now has a new method get_coordinates_of_cell() that allows a developer to retrieve the location of a cell, given the cell id.