### PR TITLE
bug fix on LIVE_STREAMING of enum  NonGBRQosReference.Rename method a…

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,11 @@
 =======
 History
 =======
+0.7.3  (2022-05-09)
+-------------------
+* Bug fix on value LIVE_STREAMING of enum  NonGBRQosReference.
+* Rename method at examples>api.py
+
 0.7.2  (2022-04-01)
 -------------------
 * LocationSubscriber now has a new method get_coordinates_of_cell() that allows a developer to retrieve the location of a cell, given the cell id.

--- a/evolved5g/__init__.py
+++ b/evolved5g/__init__.py
@@ -1,7 +1,7 @@
 """Top-level package for Evolved5G_CLI."""
 
 __author__ = "EVOLVED5G project"
-__version__ = '0.7.2'
+__version__ = '0.7.3'
 
 # Uncomment next lines to give direct import access to modules
 #from . import cli

--- a/evolved5g/sdk.py
+++ b/evolved5g/sdk.py
@@ -174,7 +174,7 @@ class QosAwareness:
             NEF Emulator has an endpoint that explains these GET /api/v1/qosInfo/qosCharacteristics
         """
         TCP_BASED = 9
-        LIVE_STREAMING = 8
+        LIVE_STREAMING = 7
 
     class GBRQosReference(Enum):
         """

--- a/examples/api.py
+++ b/examples/api.py
@@ -10,7 +10,7 @@ def index():
     return "evolved5G echo web-server started"
 
 @app.route('/monitoring/callback', methods=['POST'])
-def location_reporter():
+def handle_callback_notification():
     print("New notification retrieved:")
     print(request.get_json())
     return request.get_json()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.7.2
+current_version = 0.7.3
 commit = True
 tag = True
 


### PR DESCRIPTION
bug fix on LIVE_STREAMING value of enum  NonGBRQosReference.
Rename method at examples > api.py