### PR TITLE
Update of the SDK library, CAPIFExposerConnector CAPIFInvokerConnector

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,12 @@
 =======
 History
 =======
+0.8.7 (2024-11-23)
+-------------------
+Update of the SDK library:
+CAPIFExposerConnector and CAPIFInvokerConnector have capif_http_port and capif_https_port declared as "str" (via type hinting)
+If the developer passes the parameter as integer we make sure it's casted to string and the code does not fail
+
 0.8.6 (2022-11-23)
 -------------------
 Update of the SDK library, on how the CAPIF endpoints are constructed.

--- a/evolved5g/__init__.py
+++ b/evolved5g/__init__.py
@@ -1,7 +1,7 @@
 """Top-level package for Evolved5G_CLI."""
 
 __author__ = "EVOLVED5G project"
-__version__ = '0.8.6'
+__version__ = '0.8.7'
 
 # Uncomment next lines to give direct import access to modules
 #from . import cli

--- a/evolved5g/sdk.py
+++ b/evolved5g/sdk.py
@@ -780,6 +780,9 @@ class CAPIFInvokerConnector:
         """
         # add the trailing slash if it is not already there using os.path.join
         self.folder_to_store_certificates = os.path.join(folder_to_store_certificates.strip(), '')
+        # make sure the parameters are str
+        capif_http_port = str(capif_http_port)
+        capif_https_port = str(capif_https_port)
         if len(capif_http_port) == 0 or int(capif_http_port) == 80:
             self.capif_http_url = "http://" + capif_host.strip() + "/"
         else:
@@ -968,7 +971,9 @@ class CAPIFExposerConnector:
         self.certificates_folder = os.path.join(certificates_folder.strip(), '')
         self.description = description
         self.csr_common_name = capif_netapp_username
-
+        # make sure the parameters are str
+        capif_http_port = str(capif_http_port)
+        capif_https_port = str(capif_https_port)
         if len(capif_http_port) == 0 or int(capif_http_port) == 80:
             self.capif_http_url = "http://" + capif_host.strip() + "/"
         else:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.8.6
+current_version = 0.8.7
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/EVOLVED-5G/SDK-CLI',
-    version='0.8.6',
+    version='0.8.7',
     zip_safe=False,
 )


### PR DESCRIPTION
CAPIFExposerConnector and CAPIFInvokerConnector constructors, have capif_http_port and capif_https_port declared as "str" (via type hinting)
If the developer passes the parameter as integer we make sure it's casted to string and the code does not fail