### PR TITLE
Libraries, Bug fix on CAPIFProviderConnector: (#128)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,9 @@
 =======
 History
 =======
+1.0.1 (2023-03-03)
+* Bug fix on CAPIFProviderConnector: If you run it twice (for example for testing purposes) the .pem certificate should be overriden.
+-------------------
 1.0.0 (2023-01-03)
 -------------------
 * CAPIFExposerConnector has been a) refactored to conform to the latest CAPIF API and b) renamed to `CAPIFProviderConnector`

--- a/evolved5g/__init__.py
+++ b/evolved5g/__init__.py
@@ -1,7 +1,7 @@
 """Top-level package for Evolved5G_CLI."""
 
 __author__ = "EVOLVED5G project"
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 # Uncomment next lines to give direct import access to modules
 # from . import cli

--- a/evolved5g/sdk.py
+++ b/evolved5g/sdk.py
@@ -1189,7 +1189,7 @@ class CAPIFProviderConnector:
         Retrieves and stores the cert_server.pem from CAPIF
         """
         print("Retrieve capif_cert_server.pem , process may take a few minutes")
-        cmd = "openssl s_client -connect {0}:443  | openssl x509 -text >> {1}/capif_cert_server.pem".format(
+        cmd = "openssl s_client -connect {0}:443  | openssl x509 -text > {1}/capif_cert_server.pem".format(
             self.capif_host, self.certificates_folder
         )
         os.system(cmd)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.0
+current_version = 1.0.1
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/EVOLVED-5G/SDK-CLI",
-    version="1.0.0",
+    version="1.0.1",
     zip_safe=False,
 )


### PR DESCRIPTION
* update capif exposer onboarding function to conform with the flow of the latest CAPIF version.

* initialize TSNManager + reformat with blackd

* encapsulate TSNProfile, NetAppIdentifier, TSNProfileConfiguration classes into TSNManager

* cleanup

* Add basic usage examples of TSNManager

* Update docstrings for TSNManager

* Update the docstrings of TSNManager usage examples

* publishing services gia capif provider connector class

* rename class

* add comments to help troubleshooting with Stavros

* rollback to yesterdays version

* Rename NetappTrafficIdentifier to TSNNetAppIdentifier

* Add CLI command to get TSN profiles

* add comments for troubleshooting

* add comments for troubleshooting

* add comments for troubleshooting

* add comments for troubleshooting

* remove comments, troubleshooting

* rename capif cert pem

* rename capif cert pem

* rename TSNManager host and port attribute

* replace example host to match docker config

* reformat with black connector

* remove merge artifact

* bugfix key-value deduplication

* simplify TSN example

* enrich CLI commands for TSN

* NetApp registration now conforms to the latest version of CAPIF

* Extend ServiceDiscover with a new method get_access_token, that allows to retrieve an access token for a given api_name and aef_profile

* add comments back in

* add comments back in

* Service Discovered, security context should be created only once for a given aef_id

* remove properties from payloads that are not used

* SDK now sends the CAPIF access token to NEF. SDK Libraries constructros dont expect NEF token as a parameter

* update SDK Libraries constructors in the examples folder

* update examples

* print messages

* bug fix

* bug fix

* fix self_signed_certificate warning

* pass CERT_NONE to cert_reqs

* fix verification of SSL to libraries

* troubleshoot capif nef onboarding issue with Stavros

* provide example for TSN

* split examples service discoverer

* update TSN communication to happen via CAPIF registrered endpoints

* update NEF communication, send both NEF and CAPIF tokens

* refactor examples for Providers (TSN and NEF).

* bug fix on retrieving token from NEF

* remove print statement

* bug fix

* add comments to the examples

* TSN examples

* update documentation

* update version

* bug fix on access token

* bug fix on access token

* bug fix when creating the capif_cert_server.pem,  the file should always be overriden every time it is generated

* merge

* update version

---------