### PR TITLE
Libraries - add the development mode in the register_and_onboard_to_c…

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,13 @@ History
 =======
 
 -------------------
+1.0.7 (2023-06-15)
+-------------------
+* Bug fix on CLI method register_and_onboard_to_capif: Now accepts a second parameter --environment that takes values "production" or "development".
+If this parameter is set to production then validation tests are running in the background, just after the registration and onboarding of the network app finishes.
+
+
+-------------------
 1.0.6 (2023-06-14)
 -------------------
 

--- a/evolved5g/cli.py
+++ b/evolved5g/cli.py
@@ -91,10 +91,14 @@ def validation(ctx, repo, user, passwd, environment, deploy, email, version):
                 --csr_email_address: The email that will be used in the generated X.509 certificate              
               """,
 )
+@click.option('--environment',type=click.Choice(['production', 'development'], case_sensitive=False))
 @click.pass_context
-def register_and_onboard_to_capif(ctx, config_file_full_path: str):
+def register_and_onboard_to_capif(ctx, config_file_full_path: str,environment:str):
     ctx.obj["helper"].register_and_onboard_to_capif(config_file_full_path)
-    # ctx.obj["helper"].test_capif_and_nef_published_to_capif_endpoints(config_file_full_path)
+    if environment == "production":
+        ctx.obj["helper"].validate_all_endpoints_returned_by_service_discoverer(config_file_full_path)
+
+
 
 
 @cli.command()

--- a/evolved5g/cli_helper.py
+++ b/evolved5g/cli_helper.py
@@ -1,4 +1,4 @@
-from .nef_and_tsn_api_service_tests import test_capif_and_nef_published_to_capif_endpoints
+from .nef_and_tsn_api_service_validation_pipeline import validate_all_endpoints_returned_by_service_discoverer
 from .utils import cookiecutter_generate
 import requests
 import json
@@ -94,7 +94,7 @@ class CLI_helper:
                         resp = requests.post(
                             self.url_curl, headers=self.header, data=data
                         )
-                        
+
                         if (resp.json()['status'] == 403):
                             echo(f"{resp.json()['detail']} Please wait until your previous pipeline has finished.")
                         else:
@@ -266,7 +266,7 @@ class CLI_helper:
                             else:
                                 echo(
                                     f"Your pipeline ID is: {resp.json()['job_id']} and the actual status is: {resp.json()['status']}.")
-                            
+
                     else:
                         echo(
                             f"The {mode} you have chosen does not exist, please check the modes and try again"
@@ -453,7 +453,7 @@ class CLI_helper:
             f'\nStore the token "{clearance_token}" to clear the profile if you wish in the future.'
         )
 
-    def test_capif_and_nef_published_to_capif_endpoints(self, config_file_full_path: str) -> None:
-        test_capif_and_nef_published_to_capif_endpoints(config_file_full_path)
+    def validate_all_endpoints_returned_by_service_discoverer(self, config_file_full_path: str) -> None:
+        validate_all_endpoints_returned_by_service_discoverer(config_file_full_path)
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.6
+current_version = 1.0.7
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/EVOLVED-5G/SDK-CLI",
-    version="1.0.6",
+    version="1.0.7",
     zip_safe=False,
 )


### PR DESCRIPTION
…apif command and trigger the tests if it set to production (#145)

* update capif exposer onboarding function to conform with the flow of the latest CAPIF version.

* initialize TSNManager + reformat with blackd

* encapsulate TSNProfile, NetAppIdentifier, TSNProfileConfiguration classes into TSNManager

* cleanup

* Add basic usage examples of TSNManager

* Update docstrings for TSNManager

* Update the docstrings of TSNManager usage examples

* publishing services gia capif provider connector class

* rename class

* add comments to help troubleshooting with Stavros

* rollback to yesterdays version

* Rename NetappTrafficIdentifier to TSNNetAppIdentifier

* Add CLI command to get TSN profiles

* add comments for troubleshooting

* add comments for troubleshooting

* add comments for troubleshooting

* add comments for troubleshooting

* remove comments, troubleshooting

* rename capif cert pem

* rename capif cert pem

* rename TSNManager host and port attribute

* replace example host to match docker config

* reformat with black connector

* remove merge artifact

* bugfix key-value deduplication

* simplify TSN example

* enrich CLI commands for TSN

* NetApp registration now conforms to the latest version of CAPIF

* Extend ServiceDiscover with a new method get_access_token, that allows to retrieve an access token for a given api_name and aef_profile

* add comments back in

* add comments back in

* Service Discovered, security context should be created only once for a given aef_id

* remove properties from payloads that are not used

* SDK now sends the CAPIF access token to NEF. SDK Libraries constructros dont expect NEF token as a parameter

* update SDK Libraries constructors in the examples folder

* update examples

* print messages

* bug fix

* bug fix

* fix self_signed_certificate warning

* pass CERT_NONE to cert_reqs

* fix verification of SSL to libraries

* troubleshoot capif nef onboarding issue with Stavros

* provide example for TSN

* split examples service discoverer

* update TSN communication to happen via CAPIF registrered endpoints

* update NEF communication, send both NEF and CAPIF tokens

* refactor examples for Providers (TSN and NEF).

* bug fix on retrieving token from NEF

* remove print statement

* bug fix

* add comments to the examples

* TSN examples

* update documentation

* update version

* bug fix on access token

* bug fix on access token

* bug fix when creating the capif_cert_server.pem,  the file should always be overriden every time it is generated

* merge

* update version

* delete not used method

* TSN Manager now sends access tokens from CAPIF to the TSN API

* fix header, use Bearer tag instead of Basic

* CAPIF Logger class and example - first iteration

* CAPIF Logger class

* merge with master and update history.srt

* add class CapifAuditor, update documentation and examples

* remove python comments

* update version to 1.0.3

* bug fix on ServiceDiscoverer

* prepare helper function to test capif and nef endpoints

* remove hardcoded path from service discovery example

* tests for tsn and nef endpoints

* bug fix on specifying the https port for CAPIF when retrieving the capif_cert_server.pem certificate from capif

* ability to offboard a net app

* provide an example on how to offboard

* extend method register_and_onboard_to_capif to accept an --environment variable, create an example to showcase the offboarding

* fix de-register , add a not for establishing security contextes

* stop sending NEF tokens in the SDK classes. Use only CAPIF access tokens

* allow the SDK to create multiple security contextes to CAPIF, one for each pair of API_ID - AEF_ID

* add an example of decryption of the capif access token

* drop decrypt example

* finalize validation tests

* bug fix

* change date on history

* remove unused method

* update documentation

* add back the development mode in the register_and_onboard_to_capif command and trigger the tests if it set to production

* increment version

---------