### PR TITLE
Libraries (#151)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,12 @@
 =======
 History
 =======
+-------------------
+1.0.9 (2023-09-05)
+-------------------
+* Bug fix on CAPIFConnector.offboard method
+* Update validation pipeline, take into account the domainName in the service description, if it exists
+* Bug fix: On Service Discoverer make sure the https port parameter is utilized properly
 
 -------------------
 1.0.8 (2023-07-04)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,9 +3,10 @@ History
 =======
 
 -------------------
-1.0.8 (2023-07-05)
+1.0.8 (2023-07-04)
 -------------------
 * Bug fix on CAPIFConnector.offboard_and_deregister_netapp method
+* Update on documentation
 
 -------------------
 1.0.7 (2023-06-15)

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -21,7 +21,7 @@ From package manager
 
 .. code-block:: console
 
-    $ pip3 install evolved5g
+    $ sudo pip3 install evolved5g
 
 This is the preferred method to install Evolved5G_CLI, as it will always install the most recent stable release.
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -35,7 +35,8 @@ You can either clone the public repository:
 
 .. code-block:: console
 
-    $ git clone git://github.com/EVOLVED-5G/SDK-CLI
+    $ git clone git@github.com:EVOLVED-5G/SDK-CLI.git
+    $ git clone https://github.com/EVOLVED-5G/SDK-CLI.git
 
 Or download the `tarball`_.
 

--- a/docs/source/pipelines.rst
+++ b/docs/source/pipelines.rst
@@ -37,7 +37,7 @@ Examples of usage
 
 .. code-block:: console
 
-    evolved5g validation --repo FogusNetApp --user USERNAME --passwd USER_PASSWORD --environment ENVIRONMENT_TO_DEPLOY
+    evolved5g validation --repo REPOSITORY_NAME --user USERNAME --passwd USER_PASSWORD --environment ENVIRONMENT_TO_DEPLOY
 
 .. code-block:: console
 

--- a/evolved5g/sdk.py
+++ b/evolved5g/sdk.py
@@ -988,11 +988,17 @@ class CAPIFInvokerConnector:
     def offboard_netapp(self) ->None:
         capif_api_details = self.__load_netapp_api_details()
         url = self.capif_https_url + "api-invoker-management/v1/onboardedInvokers/" +capif_api_details["api_invoker_id"]
-        requests.request(
+
+        signed_key_crt_path = self.folder_to_store_certificates + capif_api_details["csr_common_name"] + ".crt"
+        private_key_path = self.folder_to_store_certificates + "private.key"
+
+        response = requests.request(
             "DELETE",
             url,
+            cert=(signed_key_crt_path, private_key_path),
             verify=self.folder_to_store_certificates + "ca.crt"
         )
+        response.raise_for_status()
 
 
     def offboard_and_deregister_netapp(self)->None:
@@ -1548,7 +1554,8 @@ class ServiceDiscoverer:
         :param aef_id: The aef_id that is returned by discover services
         :return: None
         """
-        url = "https://{}/capif-security/v1/trustedInvokers/{}/update".format(self.capif_host,
+        url = "https://{}:{}/capif-security/v1/trustedInvokers/{}/update".format(self.capif_host,
+                                                                                 self.capif_https_port,
                                                                        self.capif_api_details["api_invoker_id"])
 
         payload = {
@@ -1586,7 +1593,8 @@ class ServiceDiscoverer:
         :param aef_id: The aef_id that is returned by discover services
         :return: None
         """
-        url = "https://{}/capif-security/v1/trustedInvokers/{}".format(self.capif_host,
+        url = "https://{}:{}/capif-security/v1/trustedInvokers/{}".format(self.capif_host,
+                                                                          self.capif_https_port,
                                                                        self.capif_api_details["api_invoker_id"])
 
         payload = {
@@ -1623,7 +1631,8 @@ class ServiceDiscoverer:
         :return: The access token (jwt)
         """
 
-        url = "https://{}/capif-security/v1/securities/{}/token".format(self.capif_host,
+        url = "https://{}:{}/capif-security/v1/securities/{}/token".format(self.capif_host,
+                                                                           self.capif_https_port
                                                                         self.capif_api_details["api_invoker_id"])
 
         payload = {
@@ -1648,8 +1657,9 @@ class ServiceDiscoverer:
 
     def discover_service_apis(self):
 
-        url = "https://{}/{}{}".format(
+        url = "https://{}:{}/{}{}".format(
             self.capif_host,
+            self.capif_https_port,
             self.capif_api_details["discover_services_url"],
             self.capif_api_details["api_invoker_id"],
         )

--- a/examples/netapp_capif_connector_examples.py
+++ b/examples/netapp_capif_connector_examples.py
@@ -12,7 +12,7 @@ def showcase_capif_connector():
                                             capif_host="capifcore",
                                             capif_http_port="8080",
                                             capif_https_port="443",
-                                            capif_netapp_username="custom_netapp38",
+                                            capif_netapp_username="custom_netapp41",
                                             capif_netapp_password="pass123",
                                             capif_callback_url="http://localhost:5000",
                                             description= "Dummy NetApp",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.8
+current_version = 1.0.9
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/EVOLVED-5G/SDK-CLI",
-    version="1.0.8",
+    version="1.0.9",
     zip_safe=False,
 )


### PR DESCRIPTION
* update capif exposer onboarding function to conform with the flow of the latest CAPIF version.

* initialize TSNManager + reformat with blackd

* encapsulate TSNProfile, NetAppIdentifier, TSNProfileConfiguration classes into TSNManager

* cleanup

* Add basic usage examples of TSNManager

* Update docstrings for TSNManager

* Update the docstrings of TSNManager usage examples

* publishing services gia capif provider connector class

* rename class

* add comments to help troubleshooting with Stavros

* rollback to yesterdays version

* Rename NetappTrafficIdentifier to TSNNetAppIdentifier

* Add CLI command to get TSN profiles

* add comments for troubleshooting

* add comments for troubleshooting

* add comments for troubleshooting

* add comments for troubleshooting

* remove comments, troubleshooting

* rename capif cert pem

* rename capif cert pem

* rename TSNManager host and port attribute

* replace example host to match docker config

* reformat with black connector

* remove merge artifact

* bugfix key-value deduplication

* simplify TSN example

* enrich CLI commands for TSN

* NetApp registration now conforms to the latest version of CAPIF

* Extend ServiceDiscover with a new method get_access_token, that allows to retrieve an access token for a given api_name and aef_profile

* add comments back in

* add comments back in

* Service Discovered, security context should be created only once for a given aef_id

* remove properties from payloads that are not used

* SDK now sends the CAPIF access token to NEF. SDK Libraries constructros dont expect NEF token as a parameter

* update SDK Libraries constructors in the examples folder

* update examples

* print messages

* bug fix

* bug fix

* fix self_signed_certificate warning

* pass CERT_NONE to cert_reqs

* fix verification of SSL to libraries

* troubleshoot capif nef onboarding issue with Stavros

* provide example for TSN

* split examples service discoverer

* update TSN communication to happen via CAPIF registrered endpoints

* update NEF communication, send both NEF and CAPIF tokens

* refactor examples for Providers (TSN and NEF).

* bug fix on retrieving token from NEF

* remove print statement

* bug fix

* add comments to the examples

* TSN examples

* update documentation

* update version

* bug fix on access token

* bug fix on access token

* bug fix when creating the capif_cert_server.pem,  the file should always be overriden every time it is generated

* merge

* update version

* delete not used method

* TSN Manager now sends access tokens from CAPIF to the TSN API

* fix header, use Bearer tag instead of Basic

* CAPIF Logger class and example - first iteration

* CAPIF Logger class

* merge with master and update history.srt

* add class CapifAuditor, update documentation and examples

* remove python comments

* update version to 1.0.3

* bug fix on ServiceDiscoverer

* prepare helper function to test capif and nef endpoints

* remove hardcoded path from service discovery example

* tests for tsn and nef endpoints

* bug fix on specifying the https port for CAPIF when retrieving the capif_cert_server.pem certificate from capif

* ability to offboard a net app

* provide an example on how to offboard

* extend method register_and_onboard_to_capif to accept an --environment variable, create an example to showcase the offboarding

* fix de-register , add a not for establishing security contextes

* stop sending NEF tokens in the SDK classes. Use only CAPIF access tokens

* allow the SDK to create multiple security contextes to CAPIF, one for each pair of API_ID - AEF_ID

* add an example of decryption of the capif access token

* drop decrypt example

* finalize validation tests

* bug fix

* change date on history

* remove unused method

* update documentation

* add back the development mode in the register_and_onboard_to_capif command and trigger the tests if it set to production

* increment version

* DELETE a registration at CAPIF does not return a response

* DELETE a registration at CAPIF does not return a response

* update history

* fix mistake on date at history.rst

* bug fix on the offboard method

* update version

* update validation pipeline, take into account the domainName in the service description, if it exists

* bug fix: On Service Discovered make sure the https port parameter is utilized properly

* update history.rst

---------