### PR TITLE
Libraries (#163)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,17 @@ History
 =======
 
 -------------------
+1.0.13 (2023-09-18)
+-------------------
+* TSN endpoints, set ssl verify to false
+
+-------------------
+1.0.12 (2023-09-14)
+-------------------
+* Minor improvement on validation pipeline. On tests related with TSN allow the PORT to be Null in the constructor of the TSNManager class. If so, don't add the port when constructing the tsn endpoint url
+
+
+-------------------
 1.0.12 (2023-09-14)
 -------------------
 * Minor improvement on validation pipeline. On tests related with TSN allow the PORT to be Null in the constructor of the TSNManager class. If so, don't add the port when constructing the tsn endpoint url

--- a/evolved5g/sdk.py
+++ b/evolved5g/sdk.py
@@ -1818,7 +1818,7 @@ class TSNManager:
                       retrieve_specific_resource_name(self.tsn_manager.api_name, "TSN_DETAIL_PROFILE"). \
                       format(profileName=self.name)
 
-            response = requests.get(url=url, headers=self.tsn_manager.headers_auth)
+            response = requests.get(url=url, headers=self.tsn_manager.headers_auth , verify = False)
             response.raise_for_status()
             parameters_dict = json.loads(response.text)[self.name]
             return self.TSNProfileConfiguration(parameters_dict)
@@ -1833,7 +1833,7 @@ class TSNManager:
         url = self.url_prefix + self.service_discoverer. \
             retrieve_specific_resource_name(self.api_name, "TSN_LIST_PROFILES")
 
-        response = requests.get(url=url, headers=self.headers_auth)
+        response = requests.get(url=url, headers=self.headers_auth , verify= False)
         response.raise_for_status()
         response_dict = json.loads(response.text)
         return [
@@ -1863,7 +1863,7 @@ class TSNManager:
                                                                                         "TSN_APPLY_CONFIGURATION")
 
         response = requests.post(
-            url=url, json=data, headers=self.headers_auth
+            url=url, json=data, headers=self.headers_auth, verify= False
         )
         response.raise_for_status()
         response = json.loads(response.text)
@@ -1902,7 +1902,8 @@ class TSNManager:
         response = requests.post(
             url=url,
             json=data,
-            headers=self.headers_auth
+            headers=self.headers_auth,
+            verify= False
         )
         response.raise_for_status()
         response = json.loads(response.text)
@@ -1927,7 +1928,7 @@ class TSNManager:
             "token": clearance_token,
         }
         response = requests.post(
-            url=url, json=data, headers=self.headers_auth
+            url=url, json=data, headers=self.headers_auth,  verify= False
         )
         response.raise_for_status()
         assert "success" in json.loads(response.text)["message"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.12
+current_version = 1.0.13
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/EVOLVED-5G/SDK-CLI",
-    version="1.0.12",
+    version="1.0.13",
     zip_safe=False,
 )


### PR DESCRIPTION
* update capif exposer onboarding function to conform with the flow of the latest CAPIF version.

* initialize TSNManager + reformat with blackd

* encapsulate TSNProfile, NetAppIdentifier, TSNProfileConfiguration classes into TSNManager

* cleanup

* Add basic usage examples of TSNManager

* Update docstrings for TSNManager

* Update the docstrings of TSNManager usage examples

* publishing services gia capif provider connector class

* rename class

* add comments to help troubleshooting with Stavros

* rollback to yesterdays version

* Rename NetappTrafficIdentifier to TSNNetAppIdentifier

* Add CLI command to get TSN profiles

* add comments for troubleshooting

* add comments for troubleshooting

* add comments for troubleshooting

* add comments for troubleshooting

* remove comments, troubleshooting

* rename capif cert pem

* rename capif cert pem

* rename TSNManager host and port attribute

* replace example host to match docker config

* reformat with black connector

* remove merge artifact

* bugfix key-value deduplication

* simplify TSN example

* enrich CLI commands for TSN

* NetApp registration now conforms to the latest version of CAPIF

* Extend ServiceDiscover with a new method get_access_token, that allows to retrieve an access token for a given api_name and aef_profile

* add comments back in

* add comments back in

* Service Discovered, security context should be created only once for a given aef_id

* remove properties from payloads that are not used

* SDK now sends the CAPIF access token to NEF. SDK Libraries constructros dont expect NEF token as a parameter

* update SDK Libraries constructors in the examples folder

* update examples

* print messages

* bug fix

* bug fix

* fix self_signed_certificate warning

* pass CERT_NONE to cert_reqs

* fix verification of SSL to libraries

* troubleshoot capif nef onboarding issue with Stavros

* provide example for TSN

* split examples service discoverer

* update TSN communication to happen via CAPIF registrered endpoints

* update NEF communication, send both NEF and CAPIF tokens

* refactor examples for Providers (TSN and NEF).

* bug fix on retrieving token from NEF

* remove print statement

* bug fix

* add comments to the examples

* TSN examples

* update documentation

* update version

* bug fix on access token

* bug fix on access token

* bug fix when creating the capif_cert_server.pem,  the file should always be overriden every time it is generated

* merge

* update version

* delete not used method

* TSN Manager now sends access tokens from CAPIF to the TSN API

* fix header, use Bearer tag instead of Basic

* CAPIF Logger class and example - first iteration

* CAPIF Logger class

* merge with master and update history.srt

* add class CapifAuditor, update documentation and examples

* remove python comments

* update version to 1.0.3

* bug fix on ServiceDiscoverer

* prepare helper function to test capif and nef endpoints

* remove hardcoded path from service discovery example

* tests for tsn and nef endpoints

* bug fix on specifying the https port for CAPIF when retrieving the capif_cert_server.pem certificate from capif

* ability to offboard a net app

* provide an example on how to offboard

* extend method register_and_onboard_to_capif to accept an --environment variable, create an example to showcase the offboarding

* fix de-register , add a not for establishing security contextes

* stop sending NEF tokens in the SDK classes. Use only CAPIF access tokens

* allow the SDK to create multiple security contextes to CAPIF, one for each pair of API_ID - AEF_ID

* add an example of decryption of the capif access token

* drop decrypt example

* finalize validation tests

* bug fix

* change date on history

* remove unused method

* update documentation

* add back the development mode in the register_and_onboard_to_capif command and trigger the tests if it set to production

* increment version

* DELETE a registration at CAPIF does not return a response

* DELETE a registration at CAPIF does not return a response

* update history

* fix mistake on date at history.rst

* bug fix on the offboard method

* update version

* update validation pipeline, take into account the domainName in the service description, if it exists

* bug fix: On Service Discovered make sure the https port parameter is utilized properly

* update history.rst

* fix missing comma

* bug fix

* by default TSN server should be https in the validation pipeline

* make tsn_port optional, in the constructor of the TSN manager. This is useful because in the validation pipeline we only need the domain name and not a port

* Minor improvement on validation pipeline. On tests related with TSN allow the PORT to be Null in the constructor of the TSNManager class. If so, don't add the port when constructing the tsn endpoint url

* if domainName is present in the service description, the interfaceDescription will be missing. Take this into account

* fix merge on History.rst

* verify= False on TSN endpoints

* update version

---------